### PR TITLE
refactor: use cluster_version instead of eks_version

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -1,6 +1,6 @@
 locals {
   cluster_name    = (var.cluster_name != "" ? var.cluster_name : var.nuon_id)
-  cluster_version = var.eks_version
+  cluster_version = var.cluster_version
 
   instance_types = [var.default_instance_type]
   min_size       = var.min_size

--- a/variables.tf
+++ b/variables.tf
@@ -16,7 +16,14 @@ variable "cluster_name" {
   default     = ""
 }
 
+// deprecated, use cluster_version instead
 variable "eks_version" {
+  type        = string
+  description = "The Kubernetes version to use for the EKS cluster."
+  default     = "1.28"
+}
+
+variable "cluster_version" {
   type        = string
   description = "The Kubernetes version to use for the EKS cluster."
   default     = "1.28"


### PR DESCRIPTION
Leaving eks_version in place for now to avoid breaking sandboxes.